### PR TITLE
Fix config key names

### DIFF
--- a/samples/CI2002/config.json
+++ b/samples/CI2002/config.json
@@ -8,7 +8,7 @@
 				"withOrderPlacement": true,
 				"withOrderExecution": false,
 				"withPrint": true,
-				"hifreqSubmitRate": 1.0
+				"highFrequencySubmitRate": 1.0
 			},
 			{	"sessionName": 1,
 				"iterationSteps": 500,

--- a/samples/market_share/config-mm.json
+++ b/samples/market_share/config-mm.json
@@ -14,7 +14,7 @@
 				"withOrderPlacement": true,
 				"withOrderExecution": true,
 				"withPrint": true,
-				"maxHifreqOrders": 1
+				"maxHighFrequencyOrders": 1
 			}
 		]
 	},

--- a/samples/market_share/config.json
+++ b/samples/market_share/config.json
@@ -14,7 +14,7 @@
 				"withOrderPlacement": true,
 				"withOrderExecution": true,
 				"withPrint": true,
-				"maxHifreqOrders": 1
+				"maxHighFrequencyOrders": 1
 			}
 		]
 	},

--- a/samples/test/config.json
+++ b/samples/test/config.json
@@ -8,7 +8,7 @@
 				"withOrderPlacement": true,
 				"withOrderExecution": false,
 				"withPrint": true,
-				"hifreqSubmitRate": 1.0
+				"highFrequencySubmitRate": 1.0
 			},
 			{	"sessionName": 1,
 				"iterationSteps": 500,

--- a/samples/user_class/config.json
+++ b/samples/user_class/config.json
@@ -8,7 +8,7 @@
 				"withOrderPlacement": true,
 				"withOrderExecution": false,
 				"withPrint": true,
-				"hifreqSubmitRate": 1.0
+				"highFrequencySubmitRate": 1.0
 			},
 			{	"sessionName": 1,
 				"iterationSteps": 500,


### PR DESCRIPTION
## Summary
- update sample configs to use `highFrequencySubmitRate` and `maxHighFrequencyOrders`

## Testing
- `PYTHONPATH=$PWD python3 samples/CI2002/main.py --config samples/CI2002/config.json --seed 1` *(fails: No module named 'numpy')*
- `make test` *(fails to collect tests: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844304eb30883239850c1817e22d796