### PR TITLE
Update DeepAgent usage

### DIFF
--- a/pams/agents/__init__.py
+++ b/pams/agents/__init__.py
@@ -1,5 +1,6 @@
 from .arbitrage_agent import ArbitrageAgent
 from .base import Agent
+from .deep_agent import DeepAgent
 from .dqn_agent import DQNAgent
 from .fcn_agent import FCNAgent
 from .high_frequency_agent import HighFrequencyAgent

--- a/pams/agents/deep_agent.py
+++ b/pams/agents/deep_agent.py
@@ -99,7 +99,6 @@ class SimpleLSTMNetwork:
     def backward(self, x: np.ndarray, y: int, cache: Any) -> None:
         """Backward and update weights for one sample."""
         (caches, h, c, norm, mu, var, pre, relu) = cache
-        probs = np.exp(pre * 0)  # dummy to ensure array creation
         # softmax
         ex = np.exp(
             np.dot(relu, self.W2) + self.b2 - np.max(np.dot(relu, self.W2) + self.b2)
@@ -149,7 +148,6 @@ class SimpleLSTMNetwork:
             )
             dh_next = dconcat[: self.hidden_size]
             dc_next = dc * f
-            dxi = dconcat[self.hidden_size :]
             dWf += np.outer(inp, df)
             dWi += np.outer(inp, di)
             dWo += np.outer(inp, do)

--- a/samples/deep_agent/main.py
+++ b/samples/deep_agent/main.py
@@ -49,8 +49,7 @@ def plot_simulation_results(runner: SequentialRunner, prices: List[float]) -> No
     ax2.legend()
 
     plt.tight_layout()
-    plt.savefig("simulation_results.png")
-    plt.close()
+    plt.show()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- export `DeepAgent` in agents package
- remove redundant lines in `SimpleLSTMNetwork.backward`
- display plots for deep_agent sample

## Testing
- `make check` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `poetry run isort --check --quiet .` *(fails: imports not correctly sorted)*

------
https://chatgpt.com/codex/tasks/task_e_6846465349ac83238f0a91bfd03b35c3